### PR TITLE
Github Action to automatically create release and manifest

### DIFF
--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -55,7 +55,7 @@ jobs:
       - name: Create Plugin archives and manifests
         run: |
           curl -LO https://raw.githubusercontent.com/isbeorn/nina.plugin.manifests/refs/heads/main/tools/CreateManifest.ps1?raw=true
-          pwsh CreateNET7Manifest.ps1 -file "packages/${{ env.PLUGIN_NAME }}/${{ env.PLUGIN_DLL_NAME }}.dll" -installerUrl "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.zip" -createArchive -includeAll -appendVersionToArchive
+          pwsh CreateManifest.ps1 -file "packages/${{ env.PLUGIN_NAME }}/${{ env.PLUGIN_DLL_NAME }}.dll" -installerUrl "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.zip" -createArchive -includeAll -appendVersionToArchive
           Rename-Item -Path "manifest.json" -NewName "${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.manifest.json"
 
       - name: Create Release

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -35,7 +35,7 @@ jobs:
       # This will build your solution. If the solution name differs from your plugin name, please adjust it here
       - name: Build .NET Assemblies
         run: |
-          dotnet restore
+          dotnet restore NINA.Plugin.Speckle/${{ env.PLUGIN_SLN_NAME }}.sln
           dotnet build "NINA.Plugin.Speckle/${{ env.PLUGIN_SLN_NAME }}.sln" -c Release -p:PostBuildEvent= -p:Version=${{ github.ref_name }}
 
       # If you have mkdocs documentation you want to include, you can uncomment and build it like this

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -54,7 +54,7 @@ jobs:
           Copy-Item "NINA.Plugin.Speckle/NINA.Plugin.Speckle/bin/Release/net8.0-windows/${{ env.PLUGIN_DLL_NAME }}.pdb" "packages/${{ env.PLUGIN_NAME }}/${{ env.PLUGIN_DLL_NAME }}.pdb" -Force
       - name: Create Plugin archives and manifests
         run: |
-          curl https://api.bitbucket.org/2.0/repositories/isbeorn/nina.plugin.manifests/src/main/tools/CreateNET7Manifest.ps1 >> CreateNET7Manifest.ps1
+          curl -LO https://raw.githubusercontent.com/isbeorn/nina.plugin.manifests/refs/heads/main/tools/CreateManifest.ps1?raw=true
           pwsh CreateNET7Manifest.ps1 -file "packages/${{ env.PLUGIN_NAME }}/${{ env.PLUGIN_DLL_NAME }}.dll" -installerUrl "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.zip" -createArchive -includeAll -appendVersionToArchive
           Rename-Item -Path "manifest.json" -NewName "${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.manifest.json"
 

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -16,7 +16,7 @@ permissions:
 env:
   # Adjust this to your plugin title
   PLUGIN_NAME: "Speckle Interferometry"
-  PLUGIN_SLN_NAME: "NINA.Plugin.Speckle.sln"
+  PLUGIN_SLN_NAME: "NINA.Plugin.Speckle"
   PLUGIN_DLL_NAME: "SpeckleInterferometry"
 
 jobs:
@@ -36,7 +36,7 @@ jobs:
       - name: Build .NET Assemblies
         run: |
           dotnet restore
-          dotnet build "${{ env.PLUGIN_SLN_NAME }}.sln" -c Release -p:PostBuildEvent= -p:Version=${{ github.ref_name }}
+          dotnet build "NINA.Plugin.Speckle/${{ env.PLUGIN_SLN_NAME }}.sln" -c Release -p:PostBuildEvent= -p:Version=${{ github.ref_name }}
 
       # If you have mkdocs documentation you want to include, you can uncomment and build it like this
       # - name: Build Documentation

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@da05d552573ad5aba039eaac05058a918a7bf631
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/github-action.yaml
+++ b/.github/workflows/github-action.yaml
@@ -1,0 +1,73 @@
+# This is a sample github action to build and release your plugin using a github action
+# It will run when pushing a new tag - the tag name must be your plugin version number (e.g. "1.0.0.0")
+# Replace and adjust the areas that are commented below
+# Place it into the workflow folder of your repository at .github/workflows
+name: Build and Release
+
+# Every time a new tag with the typical assembly format is pushed this will run. e.g. tag name "1.0.0.0"
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+.[0-9]+'
+
+permissions:
+  contents: write
+
+env:
+  # Adjust this to your plugin title
+  PLUGIN_NAME: "Speckle Interferometry"
+  PLUGIN_SLN_NAME: "NINA.Plugin.Speckle.sln"
+  PLUGIN_DLL_NAME: "SpeckleInterferometry"
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # In case you need more sub folders add these here
+      - name: Prepare folders
+        run: |
+          mkdir packages
+          mkdir "packages/${{ env.PLUGIN_NAME }}"
+
+      # This will build your solution. If the solution name differs from your plugin name, please adjust it here
+      - name: Build .NET Assemblies
+        run: |
+          dotnet restore
+          dotnet build "${{ env.PLUGIN_SLN_NAME }}.sln" -c Release -p:PostBuildEvent= -p:Version=${{ github.ref_name }}
+
+      # If you have mkdocs documentation you want to include, you can uncomment and build it like this
+      # - name: Build Documentation
+      #   run: |
+      #     python -m pip install --upgrade pip
+      #     pip install mkdocs
+      #     pip install mkdocs-material
+      #     mkdocs build -f ${{ env.PLUGIN_NAME }}\docs\mkdocs.yml
+
+
+      # Add all necessary files that the plugin needs to the packages folder - basically all items that are normally in your post build event on your local builds
+      - name: Prepare package
+        run: |
+          Copy-Item "NINA.Plugin.Speckle/NINA.Plugin.Speckle/bin/Release/net8.0-windows/${{ env.PLUGIN_DLL_NAME }}.dll" "packages/${{ env.PLUGIN_NAME }}/${{ env.PLUGIN_DLL_NAME }}.dll" -Force
+          Copy-Item "NINA.Plugin.Speckle/NINA.Plugin.Speckle/bin/Release/net8.0-windows/${{ env.PLUGIN_DLL_NAME }}.pdb" "packages/${{ env.PLUGIN_NAME }}/${{ env.PLUGIN_DLL_NAME }}.pdb" -Force
+      - name: Create Plugin archives and manifests
+        run: |
+          curl https://api.bitbucket.org/2.0/repositories/isbeorn/nina.plugin.manifests/src/main/tools/CreateNET7Manifest.ps1 >> CreateNET7Manifest.ps1
+          pwsh CreateNET7Manifest.ps1 -file "packages/${{ env.PLUGIN_NAME }}/${{ env.PLUGIN_DLL_NAME }}.dll" -installerUrl "https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.zip" -createArchive -includeAll -appendVersionToArchive
+          Rename-Item -Path "manifest.json" -NewName "${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.manifest.json"
+
+      - name: Create Release
+        id: create_release
+        uses: softprops/action-gh-release@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          draft: false
+          prerelease: false
+          files: |
+            ./${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.zip
+            ./${{ env.PLUGIN_DLL_NAME }}.${{ github.ref_name }}.manifest.json

--- a/NINA.Plugin.Speckle/NINA.Plugin.Speckle/NINA.Plugin.Speckle.csproj
+++ b/NINA.Plugin.Speckle/NINA.Plugin.Speckle/NINA.Plugin.Speckle.csproj
@@ -1,9 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <Title>Speckle Interferometry</Title>
+    <Product>Speckle Interferometry</Product>
+    <Company>Nick Hardy &amp; Leon Bewersdorff</Company>
     <TargetFramework>net8.0-windows</TargetFramework>
     <OutputType>Library</OutputType>
     <AssemblyName>SpeckleInterferometry</AssemblyName>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
     <UseWindowsForms>true</UseWindowsForms>
     <UseWPF>true</UseWPF>
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>

--- a/NINA.Plugin.Speckle/NINA.Plugin.Speckle/Properties/AssemblyInfo.cs
+++ b/NINA.Plugin.Speckle/NINA.Plugin.Speckle/Properties/AssemblyInfo.cs
@@ -7,11 +7,11 @@ using System.Runtime.InteropServices;
 
 // [MANDATORY] The assembly versioning
 //Should be incremented for each new release build of a plugin
-[assembly: AssemblyVersion("2.2.1.3")]
-[assembly: AssemblyFileVersion("2.2.1.3")]
+//[assembly: AssemblyVersion("2.2.1.3")] Version will be filled by the dotnet build command
+//[assembly: AssemblyFileVersion("2.2.1.3")]
 
 // [MANDATORY] The name of your plugin
-[assembly: AssemblyTitle("Speckle Interferometry")]
+//[assembly: AssemblyTitle("Speckle Interferometry")]
 // [MANDATORY] A short description of your plugin
 [assembly: AssemblyDescription("This plugin automates the acquisition of speckle interferometry data for closely seperated objects.")]
 
@@ -19,9 +19,9 @@ using System.Runtime.InteropServices;
 // The following attributes are not required for the plugin per se, but are required by the official manifest meta data
 
 // Your name
-[assembly: AssemblyCompany("Nick Hardy & Leon Bewersdorff")]
+//[assembly: AssemblyCompany("Nick Hardy & Leon Bewersdorff")] Filled in csproj
 // The product name that this plugin is part of
-[assembly: AssemblyProduct("Speckle Interferometry")]
+//[assembly: AssemblyProduct("Speckle Interferometry")] Filled in csproj
 [assembly: AssemblyCopyright("")]
 
 // The minimum Version of N.I.N.A. that this plugin is compatible with
@@ -156,7 +156,7 @@ If you would like to buy Nick a whisky: [click here](https://www.paypal.com/payp
 // COM, set the ComVisible attribute to true on that type.
 [assembly: ComVisible(false)]
 // [Unused]
-[assembly: AssemblyConfiguration("")]
+//[assembly: AssemblyConfiguration("")]
 // [Unused]
 [assembly: AssemblyTrademark("")]
 // [Unused]


### PR DESCRIPTION
This pull request adds a GitHub Action to automate the plugin release process.
The workflow is tag-based and uses the tag name as the version number to apply to the built DLL.

To create a new release, simply run:
```
git tag "2.2.1.3"
git push --tags
```

The action will:

- Build the plugin with the specified version.
- Generate a release on GitHub with the built artifact.
- Automatically create a plugin manifest file.

The manifest can then be submitted to the plugin repository for distribution.

Here is a sample release on my fork: https://github.com/isbeorn/nina.speckleinterferometry/releases/tag/2.2.1.3